### PR TITLE
Added destroyAll helper function for cleaning up DB records from the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Posts.findOne(post._id);
 // => {_id: 'xevpMuN2yi92CkNfA', title: 'Hello World', author: {_id: 'testAuthorId', name: 'jon'}}
 ```
 
+#### FactoryBoy.destroyAll(name)
+
+Removes all documents in the collection using the given factory.
+
+```javascript
+var post = FactoryBoy.destroyAll('post');
+```
+
 ## Examples
 
 #### Testing

--- a/lib/factory_boy.js
+++ b/lib/factory_boy.js
@@ -48,3 +48,14 @@ FactoryBoy.build = function (name, newAttr) {
   var doc = _.merge({}, factory.attributes, newAttr);
   return doc;
 };
+
+FactoryBoy.destroyAll = function(name) {
+  var factory = this._getFactory(name);
+  var collection = factory.collection;
+
+  var collectionRecords = collection.find().fetch();
+
+  collectionRecords.forEach(function(record) {
+    collection.remove({_id: record._id});
+  });
+}

--- a/tests/factory_boy_tests.js
+++ b/tests/factory_boy_tests.js
@@ -115,3 +115,19 @@ Tinytest.add('.build - can overwrite a nested attribute', function (test) {
   // Teardown
   FactoryBoy._factories = [];
 });
+
+Tinytest.add('.destroyAll - removes all records', function (test) {
+  // Setup
+  FactoryBoy.define('fruit', Fruits, {name: 'banana'});
+  Fruits.insert({name: 'apple'});
+  Fruits.insert({name: 'orange'});
+  test.equal(Fruits.find().count(), 2);
+
+  // Act
+  FactoryBoy.destroyAll('fruit');
+  test.equal(Fruits.find().count(), 0);
+
+  // Teardown
+  FactoryBoy._factories = [];
+  Fruits.remove({});
+});


### PR DESCRIPTION
Since .remove({}) is not allowed to be called from the client side in Meteor, I found it useful to have a helper method for destroying the records of a collection in order to keep the test database clean, for instance when doing client integration tests.
